### PR TITLE
Add postgres index on logs in transaction table  

### DIFF
--- a/database/postgresql/schema.sql
+++ b/database/postgresql/schema.sql
@@ -58,6 +58,7 @@ CREATE TABLE transaction
 CREATE INDEX transaction_hash_index ON transaction (hash);
 CREATE INDEX transaction_height_index ON transaction (height);
 CREATE INDEX transaction_partition_id_index ON transaction (partition_id);
+CREATE INDEX transaction_logs_index ON transaction USING GIN(logs);
 
 CREATE TABLE message
 (


### PR DESCRIPTION
Query example that will be used by the evm-indexer to find polymer gas used for a specific transaction found via events

```
SELECT t.*
FROM transaction t
WHERE t.logs @> '[
  {
    "events": [
      {
        "type": "channel_open_try",
        "attributes": [
          {"key": "port_id", "value": "polyibc.base-realproof-2.C8F2eaab755BCB0922A6633b467C6648e8e28386"},
          {"key": "channel_id", "value": "channel-3"}
        ]
      }
    ]
  }
]';
```